### PR TITLE
Bugfix - do not add leaning slash (/) to absolute links

### DIFF
--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -72,7 +72,7 @@ export function parseUrl (url) {
       newUrl = localizedRoute(newUrl);
     }
   }
-  newUrl = newUrl.startsWith('/') ? newUrl : `/${newUrl}`;
+  newUrl = newUrl.startsWith('/') || new RegExp('^(https://|http://|www.)').test(newUrl) ? newUrl : `/${newUrl}`;
   return newUrl;
 }
 


### PR DESCRIPTION
This fixes the issues with links link http://<original-url>.com/<external-url>.com